### PR TITLE
[FIX] compile issue MacOS 10.14.6

### DIFF
--- a/src/chromSimMatrix.h
+++ b/src/chromSimMatrix.h
@@ -4,6 +4,7 @@
 #include <vector>
 #include "utils.h"
 #include "similarityMatrix.h"
+#include <numeric>
 
 namespace DIAlign 
 {

--- a/src/chromSimMatrix.h
+++ b/src/chromSimMatrix.h
@@ -2,9 +2,9 @@
 #define CHROMSIMMATRIX_H
 
 #include <vector>
+#include <numeric>
 #include "utils.h"
 #include "similarityMatrix.h"
-#include <numeric>
 
 namespace DIAlign 
 {


### PR DESCRIPTION
Ran into compile issue with clang++ (clang version 4.0.1, MacOS 10.14.6).

```
 clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -    DNDEBUG  -I"/Library/Frameworks/R.framework/Versions/3.6/Resources/library/R    cpp/include" -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -    I/usr/local/include  -fPIC  -Wall -g -O2  -c chromSimMatrix.cpp -o chromSimM    atrix.o
chromSimMatrix.cpp:14:45: error: no member named 'accumulate' in namespace '    std'
for (const auto& v : vov) average += std::accumulate( v.begin(), v.end(),     0.0)/v.size();
                                       ~~~~~^
chromSimMatrix.cpp:20:41: error: no member named 'accumulate' in namespace '    std'
for (const auto& v : vov) sos += std::accumulate( v.begin(), v.end(), 0.0,     square<double>());
                                    ~~~~~^
 2 errors generated.
```

Added additional include to chromSimMatrix.h for std::accumulate.